### PR TITLE
Use no files besides spec

### DIFF
--- a/rpmbuild/SPECS/esl-erlang-compat.spec
+++ b/rpmbuild/SPECS/esl-erlang-compat.spec
@@ -4,7 +4,6 @@ Release: 1
 Summary: A compat file to get esl-erlang to provide erlang
 URL:  https://github.com/jasonmcintosh/esl-erlang-compat
 License: MPLv1.1 and MIT and ASL 2.0 and BSD
-Source0: $_sourcedir/esl-erlang-compat.tar.gz
 BuildArch: noarch
 Requires: esl-erlang >= R16B03
 Provides: erlang
@@ -14,19 +13,12 @@ BuildRoot: %{_tmppath}/%{name}-root
 A compat file to allow esl-erlang to provide erlang dependencies.  Updated to 16B03 for rabbitmq 3.6.0
 
 %prep
-%setup -qn esl-erlang-compat
-
 
 %build
 
 %install
-rm -rf $RPM_BUILD_ROOT
-mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/esl-erlang-compat/
-cp -p version.txt $RPM_BUILD_ROOT%{_sysconfdir}/esl-erlang-compat/
 
 %files
-%defattr(-,root,root)
-%{_sysconfdir}/esl-erlang-compat/version.txt
 
 %changelog
 * Wed Jul 5 2015 Jason McIntosh <mcintoshj@gmail.com>


### PR DESCRIPTION
It's unnecessary to have the tarball, you can make an RPM with just a spec file
