### PR TITLE
Minimum required version is 19.3.6

### DIFF
--- a/rpmbuild/SPECS/esl-erlang-compat.spec
+++ b/rpmbuild/SPECS/esl-erlang-compat.spec
@@ -1,16 +1,16 @@
 Name: esl-erlang-compat
-Version: 19.0
+Version: 19.3.6
 Release: 1
 Summary: A compat file to get esl-erlang to provide erlang
 URL:  https://github.com/jasonmcintosh/esl-erlang-compat
 License: MPLv1.1 and MIT and ASL 2.0 and BSD
 BuildArch: noarch
-Requires: esl-erlang >= 19.0
+Requires: esl-erlang >= 19.3.6
 Provides: erlang
 BuildRoot: %{_tmppath}/%{name}-root
 
 %description
-A compat file to allow esl-erlang to provide erlang dependencies.  Updated to 19 for rabbitmq 3.6.0
+A shim (compatibility) package to allow esl-erlang to provide an erlang package dependency.
 
 %prep
 
@@ -21,6 +21,9 @@ A compat file to allow esl-erlang to provide erlang dependencies.  Updated to 19
 %files
 
 %changelog
+* Tue Feb 20 2018 Michael Klishin <michael@clojurewerkz.org>
+- Updated to use 19.3.6 as minimum version
+
 * Wed Aug 17 2016 Gabriele Santomaggio <g.santomaggio@gmail.com>
 - Updated to use 19.0 as minimum version
 


### PR DESCRIPTION
For joint RabbitMQ 3.6.15 and 3.7.x compatibility. Note that another PR will bump it further to 20.2.2
but perhaps some would need a 19.3 package for a transition period.