### PR TITLE
Minimum required version is 20.2.2

### DIFF
--- a/rpmbuild/SPECS/esl-erlang-compat.spec
+++ b/rpmbuild/SPECS/esl-erlang-compat.spec
@@ -1,16 +1,16 @@
 Name: esl-erlang-compat
-Version: 19.0
+Version: 19.3.6
 Release: 1
 Summary: A compat file to get esl-erlang to provide erlang
 URL:  https://github.com/jasonmcintosh/esl-erlang-compat
 License: MPLv1.1 and MIT and ASL 2.0 and BSD
 BuildArch: noarch
-Requires: esl-erlang >= 19.0
+Requires: esl-erlang >= 19.3.6
 Provides: erlang
 BuildRoot: %{_tmppath}/%{name}-root
 
 %description
-A compat file to allow esl-erlang to provide erlang dependencies.  Updated to 19 for rabbitmq 3.6.0
+A shim (compatibility) package to allow esl-erlang to provide an erlang package dependency.
 
 %prep
 
@@ -21,6 +21,9 @@ A compat file to allow esl-erlang to provide erlang dependencies.  Updated to 19
 %files
 
 %changelog
+* Tue Feb 20 2018 Michael Klishin <michael@clojurewerkz.org>
+- Updated to use 19.3.6 as minimum version
+
 * Wed Aug 17 2016 Gabriele Santomaggio <g.santomaggio@gmail.com>
 - Updated to use 19.0 as minimum version
 

--- a/rpmbuild/SPECS/esl-erlang-compat.spec
+++ b/rpmbuild/SPECS/esl-erlang-compat.spec
@@ -1,11 +1,11 @@
 Name: esl-erlang-compat
-Version: 19.3.6
+Version: 20.2.2
 Release: 1
 Summary: A compat file to get esl-erlang to provide erlang
 URL:  https://github.com/jasonmcintosh/esl-erlang-compat
 License: MPLv1.1 and MIT and ASL 2.0 and BSD
 BuildArch: noarch
-Requires: esl-erlang >= 19.3.6
+Requires: esl-erlang >= 20.2.2
 Provides: erlang
 BuildRoot: %{_tmppath}/%{name}-root
 
@@ -21,6 +21,9 @@ A shim (compatibility) package to allow esl-erlang to provide an erlang package 
 %files
 
 %changelog
+* Tue Feb 20 2018 Michael Klishin <michael@clojurewerkz.org>
+- Updated to use 20.2.2 as minimum version
+
 * Tue Feb 20 2018 Michael Klishin <michael@clojurewerkz.org>
 - Updated to use 19.3.6 as minimum version
 


### PR DESCRIPTION
For joint RabbitMQ 3.6.15 and 3.7.x compatibility. Note that this PR builds on #6, which should be merged and released first.